### PR TITLE
change INCOMPLETE_PATH

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       # REQUIRED: Change these paths to match your system
       - "/path/to/config:/opt/stacks/config"       # Configuration folder
       - "/path/to/download:/opt/stacks/download"   # Downloaded files
+      - "/path/to/incomplete:/opt/stacks/incomplete"   # incomplete path
       - "/path/to/logs:/opt/stacks/logs"           # Log files
     restart: unless-stopped
     environment:

--- a/src/stacks/constants.py
+++ b/src/stacks/constants.py
@@ -9,7 +9,7 @@ import logging
 PROJECT_ROOT = Path(os.environ.get('STACKS_PROJECT_ROOT', Path(__file__).resolve().parent.parent.parent))
 
 DOWNLOAD_PATH = PROJECT_ROOT / "download"
-INCOMPLETE_PATH = PROJECT_ROOT / "download" / "incomplete"
+INCOMPLETE_PATH = PROJECT_ROOT / "incomplete"
 LOG_PATH = PROJECT_ROOT / "logs"
 CACHE_PATH = PROJECT_ROOT / "cache"
 CONFIG_PATH = PROJECT_ROOT / "config"


### PR DESCRIPTION
I am using [Calibre-Web-Automated](https://github.com/crocodilestick/Calibre-Web-Automated) to manage my e-books. This project automatically adds e-books to Calibre for management simply by placing them in the /cwa-book-ingest directory. However, it has one drawback: it adds all content in that directory indiscriminately. Therefore, I hope the incomplete directory in the Stacks project can be configured flexibly. This way, I can map the DOWNLOAD_PATH of Stacks to the cwa-book-ingest path, achieving a fully automated workflow.