### PR TITLE
Update app.js for firefox retry to work

### DIFF
--- a/web/script/app.js
+++ b/web/script/app.js
@@ -878,6 +878,22 @@ function updateHistoryList(history) {
   });
 }
 
+// Global click handler for retry buttons (event delegation for firefox)
+document.addEventListener('click', (event) => {
+  const retryBtn = event.target.closest('.retry-btn');
+  if (!retryBtn) return;
+
+  const listItem = retryBtn.closest('.list-item');
+  const md5El = listItem?.querySelector('.item-md5');
+  const md5 = md5El?.textContent?.trim();
+
+  if (md5) {
+    retryFailed(md5);
+  } else {
+    console.error('Retry button clicked but MD5 could not be found');
+  }
+});
+
 // ============================================================================
 // EVENT HANDLERS & INITIALIZATION
 // ============================================================================


### PR DESCRIPTION
Fixed the issue with retry button not working in firefox with an event listener on .retry-btn
New function on line 882 of apps.js