### PR TITLE
Fix filename extension detection for parenthesized format strings

### DIFF
--- a/src/stacks/downloader/direct.py
+++ b/src/stacks/downloader/direct.py
@@ -39,15 +39,30 @@ def download_direct(d, download_url, title=None, total_size=None, supports_resum
             # Clean filename (remove invalid characters)
             filename = re.sub(r'[<>:"/\\|?*]', '_', title)
 
-        # Validate extension - warn if suspicious but don't modify
+        # Validate and fix extension
         from stacks.constants import LEGAL_FILES
         file_ext = Path(filename).suffix.lower()
 
-        if not file_ext:
-            d.logger.warning(f"Filename has no extension: {filename}, adding .epub")
-            filename = filename + '.epub'
-        elif file_ext not in LEGAL_FILES:
-            d.logger.warning(f"Unusual file extension: {file_ext} (not in known legal files list)")
+        if not file_ext or file_ext not in LEGAL_FILES:
+            # Extension is missing or unrecognized (e.g. Path sees ".0) (mobi)" as suffix)
+            # Scan filename for a known format string like "(mobi)", "(epub)", ".mobi", etc.
+            fixed = False
+            filename_lower = filename.lower()
+            for ext in LEGAL_FILES:
+                bare = ext.lstrip('.')  # e.g. "mobi", "epub"
+                # Check for format in parentheses like "(mobi)" or "(epub)"
+                if f'({bare})' in filename_lower:
+                    # Strip the parenthesized format from the end and add proper extension
+                    filename = re.sub(rf'\s*\({re.escape(bare)}\)\s*$', '', filename, flags=re.IGNORECASE) + ext
+                    d.logger.info(f"Fixed filename extension: ({bare}) -> {ext}")
+                    fixed = True
+                    break
+            if not fixed:
+                if not file_ext:
+                    d.logger.warning(f"Filename has no extension: {filename}, adding .epub")
+                    filename = filename + '.epub'
+                else:
+                    d.logger.warning(f"Unusual file extension: {file_ext} (not in known legal files list)")
         
         # Get unique path (with subfolder if specified)
         if subfolder:


### PR DESCRIPTION
## Summary

- Fixes a bug where files downloaded from Anna's Archive are saved without a proper extension when the metadata includes the format in parentheses (e.g. `(mobi)`, `(epub)`, `(pdf)`)
- Python's `Path.suffix` misparses filenames like `Book (v5.0) (mobi)` as having extension `.0) (mobi)` instead of `.mobi`, causing downstream tools to not recognize the file type

## Problem

When the "Filepath" metadata from Anna's Archive contains the format in parentheses rather than as a dotted extension, the existing extension validation in `direct.py` fails:

1. `Path("Book (v5.0) (mobi)").suffix` returns `.0) (mobi)` 
2. This is not in `LEGAL_FILES`, so it logs a warning but doesn't fix the filename
3. The file is saved as `Book (v5.0) (mobi)` with no usable extension

## Fix

When `Path.suffix` returns an extension not in `LEGAL_FILES`, the code now scans the filename for known format strings in parentheses (e.g. `(mobi)`, `(epub)`, `(pdf)`). If found, it strips the parenthesized format from the end and appends the correct dotted extension.

**Examples:**
| Input | Output |
|-------|--------|
| `Homer - The Iliad (v5.0) (mobi)` | `Homer - The Iliad (v5.0).mobi` |
| `Some Book Title (epub)` | `Some Book Title.epub` |
| `Book With (v2.1) (pdf)` | `Book With (v2.1).pdf` |
| `Normal Book.epub` | `Normal Book.epub` (unchanged) |
| `No Extension At All` | `No Extension At All.epub` (existing fallback) |

## Test plan

- [x] Tested with real-world filename from Anna's Archive that triggered the bug
- [x] Verified normal filenames with proper extensions are not modified
- [x] Verified the existing no-extension fallback (adds `.epub`) still works
- [x] Verified filenames with version numbers in parens like `(v5.0)` are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)