### PR TITLE
Fix multi-process crash and Safari userscript compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,0 @@
-# Stacks
-
-## Deploy
-
-```bash
-deploy stacks -r    # always needs rebuild (no volume-mounted code)
-```
-
-Stacks is part of the media Docker Compose stack at `/volume2/docker/media/compose.yaml`. The deploy tool rsyncs source to `/volume2/docker/repos/stacks/`, builds the image there, and restarts the stacks service within the media stack.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# Stacks
+
+## Deploy
+
+```bash
+deploy stacks -r    # always needs rebuild (no volume-mounted code)
+```
+
+Stacks is part of the media Docker Compose stack at `/volume2/docker/media/compose.yaml`. The deploy tool rsyncs source to `/volume2/docker/repos/stacks/`, builds the image there, and restarts the stacks service within the media stack.

--- a/deploy.conf
+++ b/deploy.conf
@@ -1,5 +1,5 @@
 HOST=magician@primary
-REMOTE_PATH=/volume2/docker/repos/stacks
+REMOTE_PATH=/volume2/docker/media/stacks/src
 DOCKER="sudo /usr/local/bin/docker"
 EXCLUDE=".git __pycache__ .DS_Store /download /config /logs /cache"
 POST_REBUILD="$DOCKER build --network host -t stacks:latest . && $DOCKER compose -f /volume2/docker/media/compose.yaml up -d stacks"

--- a/deploy.conf
+++ b/deploy.conf
@@ -1,5 +1,5 @@
 HOST=magician@primary
 REMOTE_PATH=/volume2/docker/repos/stacks
 DOCKER="sudo /usr/local/bin/docker"
-EXCLUDE=".git __pycache__ .DS_Store download/ config/ logs/ cache/"
+EXCLUDE=".git __pycache__ .DS_Store /download /config /logs /cache"
 POST_REBUILD="$DOCKER build --network host -t stacks:latest . && $DOCKER compose -f /volume2/docker/media/compose.yaml up -d stacks"

--- a/deploy.conf
+++ b/deploy.conf
@@ -1,0 +1,5 @@
+HOST=magician@primary
+REMOTE_PATH=/volume2/docker/repos/stacks
+DOCKER="sudo /usr/local/bin/docker"
+EXCLUDE=.git __pycache__ .DS_Store download/ config/ logs/ cache/
+POST_REBUILD="$DOCKER build -t stacks:latest . && $DOCKER compose -f /volume2/docker/media/compose.yaml up -d stacks"

--- a/deploy.conf
+++ b/deploy.conf
@@ -1,5 +1,5 @@
 HOST=magician@primary
 REMOTE_PATH=/volume2/docker/repos/stacks
 DOCKER="sudo /usr/local/bin/docker"
-EXCLUDE=.git __pycache__ .DS_Store download/ config/ logs/ cache/
-POST_REBUILD="$DOCKER build -t stacks:latest . && $DOCKER compose -f /volume2/docker/media/compose.yaml up -d stacks"
+EXCLUDE=".git __pycache__ .DS_Store download/ config/ logs/ cache/"
+POST_REBUILD="$DOCKER build --network host -t stacks:latest . && $DOCKER compose -f /volume2/docker/media/compose.yaml up -d stacks"

--- a/src/stacks/api/config.py
+++ b/src/stacks/api/config.py
@@ -203,9 +203,9 @@ def api_config_test_key():
         # Use domain rotation to test the key
         result = try_domains_until_success(_test_key_single_domain, test_key)
 
-        # Update the worker's cached info with timestamp
+        # Update the worker's cached info with timestamp (debug/single-process mode only)
         worker = current_app.stacks_worker
-        if worker.downloader.fast_download_key == test_key:
+        if worker and worker.downloader.fast_download_key == test_key:
             worker.downloader.fast_download_info.update({
                 'available': True,
                 'downloads_left': result['downloads_left'],

--- a/web/tamper/stacks_extension.user.js
+++ b/web/tamper/stacks_extension.user.js
@@ -555,39 +555,72 @@
     function apiRequest({ method = 'GET', path = '/', body = null, baseUrl, apiKey, timeout = 15000 }) {
         const urlBase = baseUrl || CONFIG.serverUrl;
         const key = apiKey || CONFIG.apiKey;
+        const url = urlBase.replace(/\/+$/, '') + path;
+        const headers = {
+            'X-API-Key': key,
+            'Content-Type': 'application/json',
+        };
 
-        return new Promise((resolve, reject) => {
-            GM_xmlhttpRequest({
-                method,
-                url: urlBase.replace(/\/+$/, '') + path,
-                headers: {
-                    'X-API-Key': key,
-                    'Content-Type': 'application/json',
-                },
-                data: body ? JSON.stringify(body) : undefined,
-                timeout,
-                onload: (response) => {
-                    let data = null;
-                    try {
-                        if (response.responseText) {
-                            data = JSON.parse(response.responseText);
-                        }
-                    } catch (e) {
-                        // ignore
-                    }
-                    resolve({
-                        status: response.status,
-                        statusText: response.statusText,
-                        data,
-                        raw: response,
+        // Try fetch first (works on all browsers when server has CORS enabled).
+        // Fall back to GM_xmlhttpRequest for cross-origin requests without CORS.
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), timeout);
+
+        return fetch(url, {
+            method,
+            headers,
+            body: body ? JSON.stringify(body) : undefined,
+            signal: controller.signal,
+        }).then(async (response) => {
+            clearTimeout(timer);
+            let data = null;
+            try {
+                data = await response.json();
+            } catch (e) {
+                // ignore
+            }
+            return {
+                status: response.status,
+                statusText: response.statusText,
+                data,
+                raw: response,
+            };
+        }).catch((fetchErr) => {
+            clearTimeout(timer);
+            if (fetchErr.name === 'AbortError') {
+                throw new Error('Request timed out');
+            }
+            // fetch failed (likely CORS) — try GM_xmlhttpRequest
+            return new Promise((resolve, reject) => {
+                try {
+                    GM_xmlhttpRequest({
+                        method,
+                        url,
+                        headers,
+                        data: body ? JSON.stringify(body) : undefined,
+                        timeout,
+                        onload: (response) => {
+                            let data = null;
+                            try {
+                                if (response.responseText) {
+                                    data = JSON.parse(response.responseText);
+                                }
+                            } catch (e) {
+                                // ignore
+                            }
+                            resolve({
+                                status: response.status,
+                                statusText: response.statusText,
+                                data,
+                                raw: response,
+                            });
+                        },
+                        onerror: () => reject(new Error('Failed to connect to Stacks server')),
+                        ontimeout: () => reject(new Error('Request timed out')),
                     });
-                },
-                onerror: () => {
+                } catch (e) {
                     reject(new Error('Failed to connect to Stacks server'));
-                },
-                ontimeout: () => {
-                    reject(new Error('Request timed out'));
-                },
+                }
             });
         });
     }


### PR DESCRIPTION
## Summary

Two bug fixes:

### 1. Fix `test_key` endpoint crash in multi-process mode
`api_config_test_key()` accesses `current_app.stacks_worker.downloader` without checking if `stacks_worker` is `None`. In production (multi-process mode via gunicorn), the worker runs in a separate process and `stacks_worker` is set to `None` on the Flask app. This causes:

```
Connection failed: 'NoneType' object has no attribute 'downloader'
```

whenever a user tests their Anna's Archive secret key in the settings UI. The fix adds a `None` guard — the worker cache update is only relevant in debug/single-process mode anyway.

### 2. Fix userscript silent failure on Safari (Userscripts extension)
Safari's Userscripts extension has a broken `GM_xmlhttpRequest` implementation — callbacks (`onload`, `onerror`, `ontimeout`) never fire, causing the script to hang silently. This means:

- Connection test in settings never completes ("Connecting..." forever)
- `fetchSubdirectories()` never resolves, blocking `init()` 
- Download buttons never get injected
- Version check never completes

The fix changes `apiRequest()` to use `fetch` as the primary request method and fall back to `GM_xmlhttpRequest` only when `fetch` fails (e.g. CORS not available). This works on both Safari and Chrome/Firefox:

- **Safari (Userscripts)**: `fetch` works when the server has CORS enabled (Flask-CORS is already included)
- **Chrome/Firefox (Tampermonkey)**: `fetch` works with CORS, or falls back to `GM_xmlhttpRequest` for cross-origin requests without CORS

Note: for Safari users connecting to a remote server over HTTPS (e.g. via a Caddy reverse proxy), the server's CORS headers from Flask-CORS are sufficient — no additional CORS configuration is needed on the proxy.